### PR TITLE
Txid is always all in the tx event callback function

### DIFF
--- a/hfc/fabric/channel/channel_eventhub.py
+++ b/hfc/fabric/channel/channel_eventhub.py
@@ -318,7 +318,7 @@ class ChannelEventHub(object):
                     txFilter = BlockMetadataIndex.Value('TRANSACTIONS_FILTER')
                     txStatusCodes = block['metadata']['metadata'][txFilter]
                     status = TxValidationCode.Name(txStatusCodes[index])
-                    er.onEvent(tx_id, status, block['header']['number'])
+                    er.onEvent(channel_header['tx_id'], status, block['header']['number'])
                 if er.unregister:
                     self.unregisterTxEvent(tx_id)
                 if er.disconnect:

--- a/hfc/fabric/channel/channel_eventhub.py
+++ b/hfc/fabric/channel/channel_eventhub.py
@@ -302,7 +302,7 @@ class ChannelEventHub(object):
             if tx_id == ft['txid'] or tx_id == 'all':
 
                 if er.onEvent is not None:
-                    er.onEvent(tx_id, ft['tx_validation_code'],
+                    er.onEvent(ft['txid'], ft['tx_validation_code'],
                                block['number'])
                 if er.unregister:
                     self.unregisterTxEvent(tx_id)

--- a/hfc/fabric/channel/channel_eventhub.py
+++ b/hfc/fabric/channel/channel_eventhub.py
@@ -384,9 +384,9 @@ class ChannelEventHub(object):
                         }]
                     else:
                         for x in all_events[ccid]:
-                            _uuid = x.keys()[0]
+                            _uuid = next(iter(x.keys()))
                             if _uuid == cr.uuid:
-                                x['evts'] += [evt]
+                                x[_uuid]['evts'] += [evt]
                                 break
                         else:
                             all_events[ccid].append({

--- a/test/integration/e2e_mutual_tls_test.py
+++ b/test/integration/e2e_mutual_tls_test.py
@@ -809,12 +809,7 @@ class E2eMutualTest(BaseTestCase):
             'block_number': block_number
         }
 
-        if tx_id == 'all':
-            if tx_id not in self.txs:
-                self.txs[tx_id] = []
-            self.txs[tx_id] += [o]
-        else:
-            self.txs[tx_id] = o
+        self.txs[tx_id] = o
 
     async def get_tx_events(self):
 
@@ -837,7 +832,7 @@ class E2eMutualTest(BaseTestCase):
 
         channel_event_hub.disconnect()
 
-        self.assertEqual(len(self.txs['all']), 4)
+        self.assertEqual(len(self.txs.keys()), 4)
 
     def test_in_sequence(self):
 

--- a/test/integration/e2e_test.py
+++ b/test/integration/e2e_test.py
@@ -627,12 +627,7 @@ class E2eTest(BaseTestCase):
             'block_number': block_number
         }
 
-        if tx_id == 'all':
-            if tx_id not in self.txs:
-                self.txs[tx_id] = []
-            self.txs[tx_id] += [o]
-        else:
-            self.txs[tx_id] = o
+        self.txs[tx_id] = o
 
     async def get_tx_events(self):
 
@@ -655,7 +650,7 @@ class E2eTest(BaseTestCase):
 
         channel_event_hub.disconnect()
 
-        self.assertEqual(len(self.txs['all']), 4)
+        self.assertEqual(len(self.txs.keys()), 4)
 
     def test_in_sequence(self):
 


### PR DESCRIPTION
When the txid parameter of the registerTxEvent function is "all"，Txid is always all in the tx event callback function

Signed-off-by: xiaomdong <xiaomdong@gmail.com>