### PR TITLE
Txid is always all in the tx event callback function

### DIFF
--- a/hfc/fabric/channel/channel_eventhub.py
+++ b/hfc/fabric/channel/channel_eventhub.py
@@ -318,7 +318,7 @@ class ChannelEventHub(object):
                     txFilter = BlockMetadataIndex.Value('TRANSACTIONS_FILTER')
                     txStatusCodes = block['metadata']['metadata'][txFilter]
                     status = TxValidationCode.Name(txStatusCodes[index])
-                    er.onEvent(tx_id, status, block['header']['number'])
+                    er.onEvent(channel_header['tx_id'], status, block['header']['number'])
                 if er.unregister:
                     self.unregisterTxEvent(tx_id)
                 if er.disconnect:

--- a/hfc/fabric/channel/channel_eventhub.py
+++ b/hfc/fabric/channel/channel_eventhub.py
@@ -302,7 +302,7 @@ class ChannelEventHub(object):
             if tx_id == ft['txid'] or tx_id == 'all':
 
                 if er.onEvent is not None:
-                    er.onEvent(tx_id, ft['tx_validation_code'],
+                    er.onEvent(ft['txid'], ft['tx_validation_code'],
                                block['number'])
                 if er.unregister:
                     self.unregisterTxEvent(tx_id)
@@ -318,7 +318,9 @@ class ChannelEventHub(object):
                     txFilter = BlockMetadataIndex.Value('TRANSACTIONS_FILTER')
                     txStatusCodes = block['metadata']['metadata'][txFilter]
                     status = TxValidationCode.Name(txStatusCodes[index])
-                    er.onEvent(channel_header['tx_id'], status, block['header']['number'])
+                    er.onEvent(channel_header['tx_id'],
+                               status,
+                               block['header']['number'])
                 if er.unregister:
                     self.unregisterTxEvent(tx_id)
                 if er.disconnect:

--- a/test/integration/e2e_test.py
+++ b/test/integration/e2e_test.py
@@ -245,22 +245,27 @@ class E2eTest(BaseTestCase):
         logger.info("E2E: Chaincode Channel Event Hub test start")
 
         def onEvent(cc_event, block_number, tx_id, tx_status):
-            self.channel_event_hub.unregisterChaincodeEvent(self.cr1)
-            self.channel_event_hub.unregisterChaincodeEvent(self.cr2)
-            self.channel_event_hub.unregisterChaincodeEvent(self.cr3)
-            self.channel_event_hub.disconnect()
+            self.ceh.unregisterChaincodeEvent(self.cr1)
+            self.ceh.unregisterChaincodeEvent(self.cr2)
+            self.ceh.unregisterChaincodeEvent(self.cr3)
+            self.ceh.disconnect()
 
         orgs = ["org1.example.com"]
         for org in orgs:
             org_admin = self.client.get_user(org, "Admin")
             # register extra chaincode event
-            self.channel_event_hub = self.client.get_channel(self.channel_name).newChannelEventHub(self.client.get_peer('peer1.' + org), org_admin)
-            stream = self.channel_event_hub.connect()
-            self.cr1 = self.channel_event_hub.registerChaincodeEvent(CC_NAME, 'invoked')
-            self.cr2 = self.channel_event_hub.registerChaincodeEvent(CC_NAME, 'invoked')
-            self.cr3 = self.channel_event_hub.registerChaincodeEvent(CC_NAME, 'invoked', onEvent=onEvent)
+            channel = self.client.get_channel(self.channel_name)
+            target_peer = self.client.get_peer('peer1.' + org)
+            self.ceh = channel.newChannelEventHub(target_peer, org_admin)
+            stream = self.ceh.connect()
+            self.cr1 = self.ceh.registerChaincodeEvent(CC_NAME, 'invoked')
+            self.cr2 = self.ceh.registerChaincodeEvent(CC_NAME, 'invoked')
+            self.cr3 = self.ceh.registerChaincodeEvent(CC_NAME, 'invoked',
+                                                       onEvent=onEvent)
 
-            await asyncio.wait_for(asyncio.gather(stream, return_exceptions=True), timeout=120)
+            await asyncio.wait_for(asyncio.gather(stream,
+                                                  return_exceptions=True),
+                                   timeout=120)
 
         logger.info("E2E: Chaincode Channel Event Hub test done")
 
@@ -656,12 +661,7 @@ class E2eTest(BaseTestCase):
             'block_number': block_number
         }
 
-        if tx_id == 'all':
-            if tx_id not in self.txs:
-                self.txs[tx_id] = []
-            self.txs[tx_id] += [o]
-        else:
-            self.txs[tx_id] = o
+        self.txs[tx_id] = o
 
     async def get_tx_events(self):
 
@@ -684,7 +684,7 @@ class E2eTest(BaseTestCase):
 
         channel_event_hub.disconnect()
 
-        self.assertEqual(len(self.txs['all']), 4)
+        self.assertEqual(len(self.txs.keys()), 4)
 
     def test_in_sequence(self):
 


### PR DESCRIPTION
When the txid parameter of the registerTxEvent function is "all"，Txid is always all in the tx event callback function.

The fix from GuillaumeCisco is useful，The KeyError: 'all' is not exist.

Signed-off-by: xiaomdong <xiaomdong@gmail.com>