### PR TITLE
Add client method to close gRPC channels

### DIFF
--- a/hfc/fabric/client.py
+++ b/hfc/fabric/client.py
@@ -265,6 +265,16 @@ class Client(object):
                 if target_name not in self._peers:
                     self._peers[target_name] = peer
 
+    async def close_grpc_channels(self):
+        """
+        Close the peers/orderers gRPC channels
+        :return:
+        """
+        for name in self._peers:
+            await self._peers[name]._channel.close()
+        for name in self._orderers:
+            await self._orderers[name]._channel.close()
+
     def set_tls_client_cert_and_key(self, client_key_file=None,
                                     client_cert_file=None):
 


### PR DESCRIPTION
Currently, gRPC connections to the peers and the orderers are never closed. That's the case even after the `Client` instance is destroyed:

```python
client = Client()
peer = Peer(...)
client._peers[mspid] = peer
del client
# gRPC channel is still open, even after the GC runs
```

This PR adds a new method `Client.close_grpc_channels` to allow callers to explicitly close the channels.

This method can typically be called prior to deleting the client.


```python
await client.close_grpc_channels()
# gRPC channels are now closed, delete the client
del client
```