### PR TITLE
Restore proposal return when it is KO

### DIFF
--- a/hfc/fabric/client.py
+++ b/hfc/fabric/client.py
@@ -1694,6 +1694,11 @@ class Client(object):
                 else:
                     _logger.debug('Proposals retrying successful.')
 
+        # if proposal was not good, return
+        if any([x.response.status != 200 for x in res]):
+            return '; '.join({x.response.message for x in res
+                             if x.response.status != 200})
+
         # send transaction to the orderer
         tran_req = utils.build_tx_req((res, proposal, header))
         tx_context_tx = create_tx_context(


### PR DESCRIPTION
When merging #18 , early return on wrong proposal was removed.
I re-add it with a better behavior to send all message from all endorsers