### PR TITLE
Add `make doc` to generate docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,4 +88,15 @@ install:
 format:
 	python3 -m autopep8 --in-place --recursive --exclude=./hfc/protos .
 
-.PHONY: check clean proto image install format test venv
+doc:
+	cd docs && make install html
+
+.PHONY: check \
+		clean \
+		doc \
+		proto \
+		image \
+		install \
+		format \
+		test \
+		venv

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -13,9 +13,14 @@ SPHINXPROJ    = fabric-sdk-py
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+# Install dependencies
+install:
+	pip3 install -r requirements.txt
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help install Makefile
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,9 +3,7 @@ Documentation for `fabric-sdk-py` package.
 Commands to build at local:
 
 ```bash
-$ pip install sphinx
-$ pip install sphinx_rtd_theme
-
+$ make install
 $ make html
 ```
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx
-sphinx_rtd_theme
-recommonmark
+sphinx>=2.4.0,<=2.4.4
+sphinx_rtd_theme>=0.4.0,<=0.4.3
+recommonmark>=0.6.0,<=0.6.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,6 @@ import sys
 
 sys.path.insert(0, os.path.abspath('.'))
 sys.path.insert(0, os.path.abspath('../../'))
-import recommonmark
 from recommonmark.transform import AutoStructify
 from hfc import VERSION
 

--- a/docs/source/tutorial.md
+++ b/docs/source/tutorial.md
@@ -5,7 +5,7 @@
 TLDR, run a quick testing.
 
 ```bash
-$ HLF_VERSION=1.4.0
+$ HLF_VERSION=1.4.6
 $ docker pull hyperledger/fabric-peer:${HLF_VERSION} \
     && docker pull hyperledger/fabric-orderer:${HLF_VERSION} \
     && docker pull hyperledger/fabric-ca:${HLF_VERSION} \


### PR DESCRIPTION
* Run `make doc` to generate html files for docs;
* Add version range for the doc dependencies;
* Update fabric version from 1.4.0 to 1.4.6 in tutorial.

Change-Id: Ie0cfb4aae6a2884438dad82de8cda5f9f26bce9c
Signed-off-by: Baohua Yang <yangbaohua@gmail.com>
Signed-off-by: Baohua Yang <baohua.yang@oracle.com>