### PR TITLE
Added Hyperledger's Rocketchat link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Recommend to read [How to Contribution](CONTRIBUTING.md) before taking action.
 * [Fabric SDK Python Wiki](https://wiki.hyperledger.org/display/fabric/Hyperledger+Fabric+SDK+Py)
 * [Hyperledger Project](https://www.hyperledger.org)
 * [Hyperledger mailing lists](http://lists.hyperledger.org/)
+* [Hyperledger's Rocket.Chat](https://chat.hyperledger.org)
 
 ## Incubation Notice
 


### PR DESCRIPTION
[Hyperledger indy-sdk README.md](https://github.com/hyperledger/indy-sdk/blob/master/README.md) contains Hyperledger's Rocket chat link. So I thought it would better to have such thing in fabric-sdk-py too.