### PR TITLE
Changed the docstring format to Sphinx in coding style docs

### DIFF
--- a/docs/source/code_style.md
+++ b/docs/source/code_style.md
@@ -17,28 +17,21 @@ In order to make the code more maintainable, and helps developers understand cod
     - Multi line docstrings should start without a leading new line.
     - Multi line docstrings should start with a one line summary followed by an empty line.
 
-* For every api which will be used by our client, the api Docstrings are mandatory. We are here following the [Sphinx docstring format](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html). For example:
+* For every api which will be used by our client, the api Docstrings are mandatory. We are here following the Python docstring format. For example:
 
 ```
 def square_root(n):
     """Calculate the square root of a number
-    :param n: the number to get the square root of
-    :raises TypeError: if n is not a number
-    :raises ValueError: if n is negative
-    :return: the square root of n
-    """
-    pass
-```
 
-To extend this style to also include type information in the arguments and return value, for example:
-
-```
-def add_value(self, value):
-    """Add a new value
-    :param value: the value to add
-    :type value: str
-    :return: list obtained after adding the new value
-    :rtype: list
+    Args:
+        n (int): the number to get the square root of
+    
+    Returns:
+        square_root (float): the square root of n
+    
+    Raises:
+        TypeError: if n is not a number
+        ValueError: if n is negative
     """
     pass
 ```

--- a/docs/source/code_style.md
+++ b/docs/source/code_style.md
@@ -17,32 +17,28 @@ In order to make the code more maintainable, and helps developers understand cod
     - Multi line docstrings should start without a leading new line.
     - Multi line docstrings should start with a one line summary followed by an empty line.
 
-* For every api which will be used by our client, the api Docstrings are mandatory. The Google style guide contains an excellent Python style guide, we should follow. For example:
+* For every api which will be used by our client, the api Docstrings are mandatory. We are here following the [Sphinx docstring format](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html). For example:
 
 ```
 def square_root(n):
-    """Calculate the square root of a number.
-
-    Args:
-        n: the number to get the square root of.
-    Returns:
-        the square root of n.
-    Raises:
-        TypeError: if n is not a number.
-        ValueError: if n is negative.
-
+    """Calculate the square root of a number
+    :param n: the number to get the square root of
+    :raises TypeError: if n is not a number
+    :raises ValueError: if n is negative
+    :return: the square root of n
     """
     pass
 ```
 
-To extend this style to also include type information in the arguments, for example:
+To extend this style to also include type information in the arguments and return value, for example:
 
 ```
 def add_value(self, value):
-    """Add a new value.
-
-    Args:
-        value (str): the value to add.
+    """Add a new value
+    :param value: the value to add
+    :type value: str
+    :return: list obtained after adding the new value
+    :rtype: list
     """
     pass
 ```


### PR DESCRIPTION
As mentioned by @dexhunter in [this](https://github.com/hyperledger/fabric-sdk-py/issues/40) issue. The documentation style is to be changed to the `Sphinx docstring format`. Hence accordingly,
- Changed the docstring of example functions
- Added Sphinx docs reference link, like it was present for `pep8 style guide`

However these changes can be merged after the documentation style is changed to Sphinx, that is after #40 is solved

Signed-off-by: rakaar <rka87338@gmail.com>