### PR TITLE
Added deocde flag to get_channel_config_with_orderer

### DIFF
--- a/hfc/fabric/channel/channel.py
+++ b/hfc/fabric/channel/channel.py
@@ -929,7 +929,7 @@ class Channel(object):
         tx_context.tx_prop_req = request
         return self.send_tx_proposal(tx_context, peers)
 
-    async def get_channel_config_with_orderer(self, tx_context, orderer):
+    async def get_channel_config_with_orderer(self, tx_context, orderer, decode=True):
         """Query the current config block for this channel
 
         :param tx_context: tx_context instance
@@ -974,9 +974,8 @@ class Channel(object):
             block = v.block
             break
 
-        block = BlockDecoder().decode(block.SerializeToString())
-
-        last_config = block['metadata']['metadata'][common_pb2.LAST_CONFIG]
+        decoded_block = BlockDecoder().decode(block.SerializeToString())
+        last_config = decoded_block['metadata']['metadata'][common_pb2.LAST_CONFIG]
 
         # if nor first block
         if 'index' in last_config['value']:
@@ -996,9 +995,14 @@ class Channel(object):
                 block = v.block
                 break
 
-            block = BlockDecoder().decode(block.SerializeToString())
+            if not decode:
+                return block.SerializeToString()
+            decoded_block = BlockDecoder().decode(block.SerializeToString())
 
-        envelope = block['data']['data'][0]
+        if not decode:
+            return block.SerializeToString()
+
+        envelope = decoded_block['data']['data'][0]
         payload = envelope['payload']
         channel_header = payload['header']['channel_header']
 

--- a/hfc/fabric/client.py
+++ b/hfc/fabric/client.py
@@ -761,7 +761,8 @@ class Client(object):
 
     async def get_channel_config_with_orderer(self, requestor,
                                               channel_name,
-                                              orderer=None):
+                                              orderer=None,
+                                              decode=True):
         """
         Get configuration block for the channel with the orderer
 
@@ -788,7 +789,8 @@ class Client(object):
 
         config_envelope = await channel.get_channel_config_with_orderer(
             tx_context,
-            target_orderer)
+            target_orderer,
+            decode)
 
         return config_envelope
 

--- a/test/fixtures/peer-base.yaml
+++ b/test/fixtures/peer-base.yaml
@@ -12,6 +12,7 @@ services:
   peer-base:
     image: hyperledger/fabric-peer:${HLF_VERSION}
     environment:
+      - CORE_CHAINCODE_BUILDER=hyperledger/fabric-ccenv:1.4.6
       - GODEBUG=netdns=go+1
       - FABRIC_LOGGING_SPEC=debug
      #- CORE_PEER_ID=peer0

--- a/test/fixtures/peer-mutual-tls.yaml
+++ b/test/fixtures/peer-mutual-tls.yaml
@@ -12,6 +12,7 @@ services:
   peer-base:
     image: hyperledger/fabric-peer:${HLF_VERSION}
     environment:
+      - CORE_CHAINCODE_BUILDER=hyperledger/fabric-ccenv:1.4.6
       - GODEBUG=netdns=go+1
       - FABRIC_LOGGING_SPEC=debug
      #- CORE_PEER_ID=peer0


### PR DESCRIPTION
Added deocde flag to `get_channel_config_with_orderer` method to have an ability to fetch config without decoding