### PR TITLE
Relax version rule on the requests package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ hkdf >= 0.0.3
 lark-parser == 0.7.1
 pycryptodomex >= 3.4.2
 pysha3 == 1.0b1
-requests == 2.20.0
+requests >= 2.20.0
 rx >= 3.0.1
 six >= 1.4.0
 protobuf >= 3.6.0


### PR DESCRIPTION
This ensures greater compatibility with projects importing `fabric-sdk-py`