### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,17 +3,17 @@
 | Name | GitHub | Chat | Email |
 |---|---|---|---|
 | Baohua Yang | yeasy | baohua | yangbaohua@gmail.com |
-| Dong Wang |  dongwangdw | wangdong | xdragon007@gmail.com |
 | Dixing Xu |  dexhunter | dexhunter | dixingxu@gmail.com |
-| Guillaume Cisco | GuillaumeCisco | GuillaumeCisco | guillaumecisco@gmail.com |
 
 ## Retired Maintainers
 
 | Name | GitHub | Chat | Email |
 |---|---|---|---|
 | Chang Chen | lafenicecc | lafenicecc | ccchenbj@cn.ibm.com |
-| David Dornseifer | dpdornseifer | david_dornseifer | dp.dornseifer@gmail.com |
 | Chen Kai | grapebaba | grapebaba | 281165273@qq.com |
+| David Dornseifer | dpdornseifer | david_dornseifer | dp.dornseifer@gmail.com |
+| Dong Wang |  dongwangdw | wangdong | xdragon007@gmail.com |
+| Guillaume Cisco | GuillaumeCisco | GuillaumeCisco | guillaumecisco@gmail.com |
 
 ## License <a name="license"></a>
 


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>