### PR TITLE
replace deprecated pysha3 with safe-pysha3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ grpcio >= 1.0.1
 hkdf >= 0.0.3
 lark-parser == 0.7.1
 pycryptodomex >= 3.4.2
-pysha3 == 1.0b1
+safe-pysha3 >= 1.0.3
 requests >= 2.20.0
 rx >= 3.0.1
 six >= 1.4.0


### PR DESCRIPTION
closes #185 