### PR TITLE
Update auth header token for CA

### DIFF
--- a/hfc/fabric_ca/affiliationService.py
+++ b/hfc/fabric_ca/affiliationService.py
@@ -38,7 +38,7 @@ class AffiliationService(object):
             'caname': caname
         }
 
-        authorization = self._client.generateAuthToken(req, registrar)
+        authorization = self._client.generateAuthToken(req, registrar,"POST")
         headers = {'Authorization': authorization}
         verify = self._client._ca_certs_path
 
@@ -68,7 +68,7 @@ class AffiliationService(object):
             raise ValueError('argument "affiliation" is not a valid string')
 
         path = 'affiliations/' + affiliation
-        authorization = self._client.generateAuthToken(None, registrar)
+        authorization = self._client.generateAuthToken(None, registrar,"GET")
         headers = {'Authorization': authorization}
         verify = self._client._ca_certs_path
         res, st = self._client._send_ca_get(path,
@@ -92,7 +92,7 @@ class AffiliationService(object):
         """
 
         path = 'affiliations'
-        authorization = self._client.generateAuthToken(None, registrar)
+        authorization = self._client.generateAuthToken(None, registrar,"GET")
         headers = {'Authorization': authorization}
         verify = self._client._ca_certs_path
         res, st = self._client._send_ca_get(path,
@@ -130,7 +130,7 @@ class AffiliationService(object):
         if force is True:
             path += '?force=true'
 
-        authorization = self._client.generateAuthToken(None, registrar)
+        authorization = self._client.generateAuthToken(None, registrar,"DELETE")
         headers = {'Authorization': authorization}
         verify = self._client._ca_certs_path
         res, st = self._client._send_ca_delete(path,
@@ -180,7 +180,7 @@ class AffiliationService(object):
         if caname:
             req['caname'] = caname
 
-        authorization = self._client.generateAuthToken(req, registrar)
+        authorization = self._client.generateAuthToken(req, registrar,"PUT")
         headers = {'Authorization': authorization}
         verify = self._client._ca_certs_path
         res, st = self._client._send_ca_update(path,

--- a/hfc/fabric_ca/affiliationService.py
+++ b/hfc/fabric_ca/affiliationService.py
@@ -1,5 +1,4 @@
 import logging
-ogging.basicConfig(level=logging.DEBUG, filename='/Users/muthu/Projects/fabric-python-logfile.log')
 _logger = logging.getLogger(__name__)
 
 

--- a/hfc/fabric_ca/affiliationService.py
+++ b/hfc/fabric_ca/affiliationService.py
@@ -1,5 +1,5 @@
 import logging
-
+ogging.basicConfig(level=logging.DEBUG, filename='/Users/muthu/Projects/fabric-python-logfile.log')
 _logger = logging.getLogger(__name__)
 
 
@@ -38,7 +38,7 @@ class AffiliationService(object):
             'caname': caname
         }
 
-        authorization = self._client.generateAuthToken(req, registrar,"POST")
+        authorization = self._client.generateAuthToken(req, registrar, path, "POST")
         headers = {'Authorization': authorization}
         verify = self._client._ca_certs_path
 
@@ -68,7 +68,7 @@ class AffiliationService(object):
             raise ValueError('argument "affiliation" is not a valid string')
 
         path = 'affiliations/' + affiliation
-        authorization = self._client.generateAuthToken(None, registrar,"GET")
+        authorization = self._client.generateAuthToken(None, registrar, path, "GET")
         headers = {'Authorization': authorization}
         verify = self._client._ca_certs_path
         res, st = self._client._send_ca_get(path,
@@ -92,7 +92,7 @@ class AffiliationService(object):
         """
 
         path = 'affiliations'
-        authorization = self._client.generateAuthToken(None, registrar,"GET")
+        authorization = self._client.generateAuthToken(None, registrar, path, "GET")
         headers = {'Authorization': authorization}
         verify = self._client._ca_certs_path
         res, st = self._client._send_ca_get(path,
@@ -130,7 +130,7 @@ class AffiliationService(object):
         if force is True:
             path += '?force=true'
 
-        authorization = self._client.generateAuthToken(None, registrar,"DELETE")
+        authorization = self._client.generateAuthToken(None, registrar, path, "DELETE")
         headers = {'Authorization': authorization}
         verify = self._client._ca_certs_path
         res, st = self._client._send_ca_delete(path,
@@ -180,7 +180,7 @@ class AffiliationService(object):
         if caname:
             req['caname'] = caname
 
-        authorization = self._client.generateAuthToken(req, registrar,"PUT")
+        authorization = self._client.generateAuthToken(req, registrar, path, "PUT")
         headers = {'Authorization': authorization}
         verify = self._client._ca_certs_path
         res, st = self._client._send_ca_update(path,

--- a/hfc/fabric_ca/caservice.py
+++ b/hfc/fabric_ca/caservice.py
@@ -238,7 +238,15 @@ class CAClient(object):
         else:
             bodyAndCert = b'.%s' % b64Cert
 
-        sig = self._cryptoPrimitives.sign(registrar._private_key, bodyAndCert)
+        # Construct the string to be signed: HTTP method + path + body + client cert
+        string_to_sign = {
+                            "http_method": "POST",
+                            "path": self._base_url,
+                            "body": b64Body.decode(),
+                            "client_cert": b64Cert.decode()
+                        }
+        string_to_sign_bytes = string_to_sign.encode()
+        sig = self._cryptoPrimitives.sign(registrar._private_key, string_to_sign_bytes)
         b64Sign = base64.b64encode(sig)
 
         # /!\ cannot mix f format and b

--- a/hfc/fabric_ca/caservice.py
+++ b/hfc/fabric_ca/caservice.py
@@ -215,7 +215,7 @@ class CAClient(object):
         self._ca_name = ca_name
         self._cryptoPrimitives = cryptoPrimitives
 
-    def generateAuthToken(self, req, registrar):
+    def generateAuthToken(self, req, registrar,http_method):
         """Generate authorization token required for accessing fabric-ca APIs
 
         :param req: request body
@@ -238,15 +238,13 @@ class CAClient(object):
         else:
             bodyAndCert = b'.%s' % b64Cert
 
-        # Construct the string to be signed: HTTP method + path + body + client cert
         string_to_sign = {
-                            "http_method": "POST",
+                            "http_method":http_method,
                             "path": self._base_url,
-                            "body": b64Body.decode(),
-                            "client_cert": b64Cert.decode()
+                            "body": bodyAndCert,
+                            "client_cert": b64Cert
                         }
-        string_to_sign_bytes = string_to_sign.encode()
-        sig = self._cryptoPrimitives.sign(registrar._private_key, string_to_sign_bytes)
+        sig = self._cryptoPrimitives.sign(registrar._private_key, string_to_sign)
         b64Sign = base64.b64encode(sig)
 
         # /!\ cannot mix f format and b
@@ -349,7 +347,7 @@ class CAClient(object):
                              .format(res['errors']))
 
     def register(self, req, registrar):
-        authorization = self.generateAuthToken(req, registrar)
+        authorization = self.generateAuthToken(req, registrar,"POST")
 
         res, st = self._send_ca_post(path="register",
                                      json=req,
@@ -366,7 +364,7 @@ class CAClient(object):
                              .format(res['errors']))
 
     def reenroll(self, req, registrar):
-        authorization = self.generateAuthToken(req, registrar)
+        authorization = self.generateAuthToken(req, registrar,"POST")
 
         res, st = self._send_ca_post(path='reenroll',
                                      json=req,
@@ -384,7 +382,7 @@ class CAClient(object):
                              .format(res['errors']))
 
     def revoke(self, req, registrar):
-        authorization = self.generateAuthToken(req, registrar)
+        authorization = self.generateAuthToken(req, registrar,"POST")
 
         res, st = self._send_ca_post(path="revoke",
                                      json=req,
@@ -401,7 +399,7 @@ class CAClient(object):
                              .format(res['errors']))
 
     def generateCRL(self, req, registrar):
-        authorization = self.generateAuthToken(req, registrar)
+        authorization = self.generateAuthToken(req, registrar,"POST")
         res, st = self._send_ca_post(path='gencrl',
                                      json=req,
                                      headers={'Authorization': authorization},

--- a/hfc/fabric_ca/caservice.py
+++ b/hfc/fabric_ca/caservice.py
@@ -32,7 +32,6 @@ from hfc.util.crypto.crypto import ecies
 
 DEFAULT_CA_ENDPOINT = 'http://localhost:7054'
 DEFAULT_CA_BASE_URL = '/api/v1/'
-logging.basicConfig(level=logging.DEBUG, filename='/Users/muthu/Projects/fabric-python-logfile.log')
 _logger = logging.getLogger(__name__)
 
 reasons = (

--- a/hfc/fabric_ca/caservice.py
+++ b/hfc/fabric_ca/caservice.py
@@ -230,27 +230,26 @@ class CAClient(object):
         if req:
             reqJson = json.dumps(req, ensure_ascii=False)
             b64Body = base64.b64encode(reqJson.encode('utf-8'))
-            bodyAndCert = b'%b.%b' % (b64Body, b64Cert)
+            bodyAndCert = b'%s.%s' % (b64Body, b64Cert)
         else:
             bodyAndCert = b'.%s' % b64Cert
-        path = self._base_url
-        string_to_sign = {
-                            "http_method": http_method,
-                            "path": path,
-                            "body": bodyAndCert.decode('utf-8'),
-                            "client_cert": b64Cert.decode('utf-8')
-                        }
         # Serialize and encode to bytes
-        string_to_sign_bytes = json.dumps(string_to_sign, ensure_ascii=False).encode('utf-8')
+        b64Path = self._base_url.encode('utf-8')
+        http_method_bytes = http_method.encode('utf-8')
+        string_to_sign = b'%s.%s.%s' % (http_method_bytes, b64Path, bodyAndCert)
+        if isinstance(string_to_sign, str):
+            string_to_sign = string_to_sign.encode('utf-8')
         # Sign the message
         try:
-            sig = self._cryptoPrimitives.sign(registrar._private_key, string_to_sign_bytes)
+            sig = self._cryptoPrimitives.sign(registrar._private_key, string_to_sign)
+            if not sig or not isinstance(sig, bytes):
+                raise ValueError("Signing failed: Signature is empty or not bytes")
             b64Sign = base64.b64encode(sig)
         except Exception as e:
             print(f"Signing failed: {e}")
             raise
         # Return the final token
-        return b'%b.%b' % (b64Cert, b64Sign)
+        return b'%s.%s' % (b64Cert, b64Sign)
 
     def _send_ca_post(self, path, **param):
         """Send a post request to the ca service

--- a/hfc/fabric_ca/certificateService.py
+++ b/hfc/fabric_ca/certificateService.py
@@ -1,6 +1,7 @@
 import logging
 import urllib.parse
 
+logging.basicConfig(level=logging.DEBUG, filename='/Users/muthu/Projects/fabric-python-logfile.log')
 _logger = logging.getLogger(__name__)
 
 
@@ -74,7 +75,7 @@ class CertificateService(object):
         if queryString:
             path += '?' + queryString
 
-        authorization = self.client.generateAuthToken(None, registrar,"GET")
+        authorization = self.client.generateAuthToken(None, registrar, path, "GET")
         headers = {'Authorization': authorization}
         verify = self.client._ca_certs_path
 

--- a/hfc/fabric_ca/certificateService.py
+++ b/hfc/fabric_ca/certificateService.py
@@ -74,7 +74,7 @@ class CertificateService(object):
         if queryString:
             path += '?' + queryString
 
-        authorization = self.client.generateAuthToken(None, registrar)
+        authorization = self.client.generateAuthToken(None, registrar,"GET")
         headers = {'Authorization': authorization}
         verify = self.client._ca_certs_path
 

--- a/hfc/fabric_ca/certificateService.py
+++ b/hfc/fabric_ca/certificateService.py
@@ -1,7 +1,6 @@
 import logging
 import urllib.parse
 
-logging.basicConfig(level=logging.DEBUG, filename='/Users/muthu/Projects/fabric-python-logfile.log')
 _logger = logging.getLogger(__name__)
 
 

--- a/hfc/fabric_ca/identityService.py
+++ b/hfc/fabric_ca/identityService.py
@@ -60,11 +60,12 @@ class IdentityService(object):
 
         if isinstance(enrollmentSecret, str) and len(enrollmentSecret):
             req['secret'] = enrollmentSecret
-
-        authorization = self._client.generateAuthToken(req, registrar,"POST")
+        path='identities'
+        authorization = self._client.generateAuthToken(req, registrar, path, "POST")
         headers = {'Authorization': authorization}
+        _logger.debug("Authorization Header",headers)
         verify = self._client._ca_certs_path
-        res, st = self._client._send_ca_post(path='identities',
+        res, st = self._client._send_ca_post(path=path,
                                              json=req,
                                              headers=headers,
                                              verify=verify)
@@ -84,7 +85,7 @@ class IdentityService(object):
             raise ValueError('argument "enrollmentID" is not a valid string')
 
         path = 'identities/' + enrollmentID + '?ca=' + self._client._ca_name
-        authorization = self._client.generateAuthToken(None, registrar,"GET")
+        authorization = self._client.generateAuthToken(None, registrar, path, "GET")
         headers = {'Authorization': authorization}
         verify = self._client._ca_certs_path
         res, st = self._client._send_ca_get(path,
@@ -99,7 +100,7 @@ class IdentityService(object):
     def getAll(self, registrar):
 
         path = 'identities?ca=' + self._client._ca_name
-        authorization = self._client.generateAuthToken(None, registrar,"GET")
+        authorization = self._client.generateAuthToken(None, registrar, path, "GET")
         headers = {'Authorization': authorization}
         verify = self._client._ca_certs_path
         res, st = self._client._send_ca_get(path,
@@ -120,7 +121,7 @@ class IdentityService(object):
         if force is True:
             path += '?force=true'
 
-        authorization = self._client.generateAuthToken(None, registrar,"DELETE")
+        authorization = self._client.generateAuthToken(None, registrar, path, "DELETE")
         headers = {'Authorization': authorization}
         verify = self._client._ca_certs_path
         res, st = self._client._send_ca_delete(path,
@@ -155,7 +156,7 @@ class IdentityService(object):
         if caname:
             req['caname'] = caname
 
-        authorization = self._client.generateAuthToken(req, registrar,"PUT")
+        authorization = self._client.generateAuthToken(req, registrar, path, "PUT")
         headers = {'Authorization': authorization}
         verify = self._client._ca_certs_path
         res, st = self._client._send_ca_update(path,

--- a/hfc/fabric_ca/identityService.py
+++ b/hfc/fabric_ca/identityService.py
@@ -61,7 +61,7 @@ class IdentityService(object):
         if isinstance(enrollmentSecret, str) and len(enrollmentSecret):
             req['secret'] = enrollmentSecret
 
-        authorization = self._client.generateAuthToken(req, registrar)
+        authorization = self._client.generateAuthToken(req, registrar,"POST")
         headers = {'Authorization': authorization}
         verify = self._client._ca_certs_path
         res, st = self._client._send_ca_post(path='identities',
@@ -84,7 +84,7 @@ class IdentityService(object):
             raise ValueError('argument "enrollmentID" is not a valid string')
 
         path = 'identities/' + enrollmentID + '?ca=' + self._client._ca_name
-        authorization = self._client.generateAuthToken(None, registrar)
+        authorization = self._client.generateAuthToken(None, registrar,"GET")
         headers = {'Authorization': authorization}
         verify = self._client._ca_certs_path
         res, st = self._client._send_ca_get(path,
@@ -99,7 +99,7 @@ class IdentityService(object):
     def getAll(self, registrar):
 
         path = 'identities?ca=' + self._client._ca_name
-        authorization = self._client.generateAuthToken(None, registrar)
+        authorization = self._client.generateAuthToken(None, registrar,"GET")
         headers = {'Authorization': authorization}
         verify = self._client._ca_certs_path
         res, st = self._client._send_ca_get(path,
@@ -120,7 +120,7 @@ class IdentityService(object):
         if force is True:
             path += '?force=true'
 
-        authorization = self._client.generateAuthToken(None, registrar)
+        authorization = self._client.generateAuthToken(None, registrar,"DELETE")
         headers = {'Authorization': authorization}
         verify = self._client._ca_certs_path
         res, st = self._client._send_ca_delete(path,
@@ -155,7 +155,7 @@ class IdentityService(object):
         if caname:
             req['caname'] = caname
 
-        authorization = self._client.generateAuthToken(req, registrar)
+        authorization = self._client.generateAuthToken(req, registrar,"PUT")
         headers = {'Authorization': authorization}
         verify = self._client._ca_certs_path
         res, st = self._client._send_ca_update(path,


### PR DESCRIPTION
When interacting with Fabric CA REST services,
utilize the updated auth header token format
that includes the URL path and method.

The old format has been deprecated for a long time (since Fabric CA v1.4.0) since the new format is more secure.
New versions of Fabric CA (v1.5.14 and later) will not support the old format by default
(although they can still support the old format by setting FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3=true).

For reference see similar change in legacy Node SDK that never got propagated to the console Fabric CA client:
https://github.com/hyperledger/fabric-sdk-node/commit/602f557cc9fa07d444bb707aeef4eb3b94757779

And the original change in Fabric CA that is driving this change:
https://github.com/hyperledger/fabric-ca/commit/99517e9d983750e7e8c9a8db9eeda7008e37d7ff

Note that the new format became effective in Fabric CA v1.4.0 (2019), therefore console will require Fabric CA v1.4.0 or later, which should not be a problem at this stage.

Resolves https://github.com/hyperledger/fabric-sdk-py/issues/196